### PR TITLE
Update to "actions/cache@4" for Node 20

### DIFF
--- a/.github/workflows/update_main_version.yml
+++ b/.github/workflows/update_main_version.yml
@@ -1,0 +1,34 @@
+name: Update Main Version
+run-name: Move ${{ github.event.inputs.major_version }} to ${{ github.event.inputs.target }}
+
+# Taken from `actions/checkout` repo under MIT License:
+# https://github.com/actions/checkout/blob/v4.1.7/.github/workflows/update-main-version.yml
+
+on:
+  workflow_dispatch:
+    inputs:
+      target:
+        description: The tag or reference to use
+        required: true
+      major_version:
+        type: choice
+        description: The major version to update
+        options:
+          - v2
+          - v1
+
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    - name: Git config
+      run: |
+        git config user.name "github-actions[bot]"
+        git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+    - name: Tag new target
+      run: git tag -f ${{ github.event.inputs.major_version }} ${{ github.event.inputs.target }}
+    - name: Push new tag
+      run: git push origin ${{ github.event.inputs.major_version }} --force

--- a/action.yml
+++ b/action.yml
@@ -27,7 +27,7 @@ runs:
       shell: bash
     - name: Cache monorepo node_modules
       if: ${{ !fromJSON(inputs.skip-cache) && fromJSON(inputs.is-monorepo) }}
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: "**/node_modules/"
         key: ${{ steps.output-os-version.outputs.version }}-node${{ steps.output-node-version.outputs.version }}-yarn-${{ hashFiles('**/yarn.lock') }}
@@ -36,7 +36,7 @@ runs:
 
     - name: Cache single-repo node_modules
       if: ${{ !fromJSON(inputs.skip-cache) && !fromJSON(inputs.is-monorepo) }}
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: "node_modules/"
         key: ${{ steps.output-os-version.outputs.version }}-node${{ steps.output-node-version.outputs.version }}-yarn-${{ hashFiles('yarn.lock') }}


### PR DESCRIPTION
- upgrade to `actions/cache@v4` so it runs Node 20 internally
- also add a workflow for releasing this action

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207702326954634