### PR TITLE
chore: upgrade deps and bump to v4

### DIFF
--- a/.github/workflows/update_main_version.yml
+++ b/.github/workflows/update_main_version.yml
@@ -14,6 +14,7 @@ on:
         type: choice
         description: The major version to update
         options:
+          - v4
           - v3
           - v2
 
@@ -21,7 +22,7 @@ jobs:
   tag:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         fetch-depth: 0
     - name: Git config

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# npm-install-with-cache-action v2
+# npm-install-with-cache-action v4
 
 ## Usage
 
@@ -18,12 +18,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-node@v4
+    - uses: actions/checkout@v6
+    - uses: actions/setup-node@v6
       with:
-        node-version: 20
+        node-version: 26
     - name: Install packages with cache
-      uses: iCHEF/npm-install-with-cache-action@v2
+      uses: iCHEF/npm-install-with-cache-action@v4
       with:
         npm-token: ${{ secrets.NPM_TOKEN }}
         engine: npm

--- a/action.yml
+++ b/action.yml
@@ -33,7 +33,7 @@ runs:
     - id: cache
       name: Cache node_modules
       if: ${{ !fromJSON(inputs.skip-cache) }}
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: "**/node_modules/"
         key: ${{ steps.output-os-version.outputs.version }}-node${{ steps.output-node-version.outputs.version }}-${{ inputs.engine }}-${{ hashFiles('**/package-lock.json', '**/yarn.lock') }}


### PR DESCRIPTION
## Summary
- 升級 `actions/cache` v4 → v5
- 升級 `actions/checkout` v4 → v6、`actions/setup-node` v4 → v6（README 範例）
- 更新 README 標題與範例為 v4
- Workflow version options 新增 v4

## Context
v3 已有 tag 但從未正式 release，此 PR 跳過 v3 直接準備 v4。